### PR TITLE
[기능] AI 코드 리뷰 및 질문 API 구현

### DIFF
--- a/src/ai-review/ai-review.controller.spec.ts
+++ b/src/ai-review/ai-review.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiReviewController } from './ai-review.controller';
+
+describe('AiReviewController', () => {
+  let controller: AiReviewController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AiReviewController],
+    }).compile();
+
+    controller = module.get<AiReviewController>(AiReviewController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/ai-review/ai-review.controller.ts
+++ b/src/ai-review/ai-review.controller.ts
@@ -4,14 +4,10 @@ import { AiReviewService } from './ai-review.service';
 import { User } from '../user/decorators/user.decorator';
 import { UserDto } from '../user/dto/user.dto';
 
-// src/ai-review/ai-review.controller.ts
-
 @Controller('sessions/:id/ai')
 export class AiReviewController {
   constructor(private readonly aiReviewService: AiReviewService) {}
 
-  // 코드 기반 리뷰
-  @UseGuards(JwtAuthGuard)
   @Post('review')
   async reviewCode(
     @User() user: UserDto,
@@ -21,8 +17,6 @@ export class AiReviewController {
     return this.aiReviewService.reviewCode(sessionId, question);
   }
 
-  // 일반 질문 (코드 없음)
-  @UseGuards(JwtAuthGuard)
   @Post('question')
   async askQuestion(
     @User() user: UserDto,

--- a/src/ai-review/ai-review.controller.ts
+++ b/src/ai-review/ai-review.controller.ts
@@ -1,4 +1,34 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Post, UseGuards, Param, ParseIntPipe, Body } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AiReviewService } from './ai-review.service';
+import { User } from '../user/decorators/user.decorator';
+import { UserDto } from '../user/dto/user.dto';
 
-@Controller('ai-review')
-export class AiReviewController {}
+// src/ai-review/ai-review.controller.ts
+
+@Controller('sessions/:id/ai')
+export class AiReviewController {
+  constructor(private readonly aiReviewService: AiReviewService) {}
+
+  // 코드 기반 리뷰
+  @UseGuards(JwtAuthGuard)
+  @Post('review')
+  async reviewCode(
+    @User() user: UserDto,
+    @Param('id', ParseIntPipe) sessionId: number,
+    @Body('question') question: string,
+  ) {
+    return this.aiReviewService.reviewCode(sessionId, question);
+  }
+
+  // 일반 질문 (코드 없음)
+  @UseGuards(JwtAuthGuard)
+  @Post('question')
+  async askQuestion(
+    @User() user: UserDto,
+    @Param('id', ParseIntPipe) sessionId: number,
+    @Body('question') question: string,
+  ) {
+    return this.aiReviewService.askQuestion(sessionId, question);
+  }
+}

--- a/src/ai-review/ai-review.controller.ts
+++ b/src/ai-review/ai-review.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('ai-review')
+export class AiReviewController {}

--- a/src/ai-review/ai-review.module.ts
+++ b/src/ai-review/ai-review.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AiReviewController } from './ai-review.controller';
 import { AiReviewService } from './ai-review.service';
+import { OpenAiService } from './openai.service';
 
 @Module({
   controllers: [AiReviewController],
-  providers: [AiReviewService]
+  providers: [AiReviewService, OpenAiService],
 })
 export class AiReviewModule {}

--- a/src/ai-review/ai-review.module.ts
+++ b/src/ai-review/ai-review.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AiReviewController } from './ai-review.controller';
+import { AiReviewService } from './ai-review.service';
+
+@Module({
+  controllers: [AiReviewController],
+  providers: [AiReviewService]
+})
+export class AiReviewModule {}

--- a/src/ai-review/ai-review.service.spec.ts
+++ b/src/ai-review/ai-review.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiReviewService } from './ai-review.service';
+
+describe('AiReviewService', () => {
+  let service: AiReviewService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AiReviewService],
+    }).compile();
+
+    service = module.get<AiReviewService>(AiReviewService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/ai-review/ai-review.service.ts
+++ b/src/ai-review/ai-review.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AiReviewService {}

--- a/src/ai-review/ai-review.service.ts
+++ b/src/ai-review/ai-review.service.ts
@@ -1,4 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { OpenAiService } from './openai.service';
 
 @Injectable()
-export class AiReviewService {}
+export class AiReviewService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly openaiService: OpenAiService,
+  ) {}
+
+  async reviewCode(sessionId: number, question: string): Promise<{ answer: string }> {
+    const session = await this.prisma.session.findUnique({ where: { id: sessionId } });
+    if (!session || session.isEnded || !session.codeLogs) {
+      throw new NotFoundException('세션 코드가 존재하지 않거나 세션이 종료되었습니다.');
+    }
+
+    const prompt = `아래 코드를 참고해서 200자 이내로 질문에 답해주세요.\n\n질문: ${question}\n\n코드:\n${session.codeLogs}`;
+    const answer = await this.openaiService.send(prompt);
+    return { answer };
+  }
+
+  async askQuestion(sessionId: number, question: string): Promise<{ answer: string }> {
+    const prompt = `다음 질문을 200자 이내로 답해주세요:\n\n${question}`;
+    const answer = await this.openaiService.send(prompt);
+    return { answer };
+  }
+}

--- a/src/ai-review/openai.service.ts
+++ b/src/ai-review/openai.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class OpenAiService {
+  private readonly apiKey = process.env.OPENAI_API_KEY;
+  private readonly model = process.env.OPENAI_MODEL || 'gpt-4';
+
+  async send(prompt: string): Promise<string> {
+    const url = 'https://api.openai.com/v1/chat/completions';
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+
+    const data = {
+      model: this.model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.7,
+    };
+
+    const response = await axios.post(url, data, { headers });
+    const answer = response.data.choices?.[0]?.message?.content?.trim();
+    return answer ?? 'AI 응답을 가져올 수 없습니다.';
+  }
+}

--- a/src/ai-review/openai.service.ts
+++ b/src/ai-review/openai.service.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 @Injectable()
 export class OpenAiService {
   private readonly apiKey = process.env.OPENAI_API_KEY;
-  private readonly model = process.env.OPENAI_MODEL || 'gpt-4'; // 모델을 지정
+  private readonly model = process.env.OPENAI_MODEL || 'gpt-4o-mini'; // 모델을 지정
 
   async send(prompt: string): Promise<string> {
     const url = 'https://api.openai.com/v1/chat/completions';

--- a/src/ai-review/openai.service.ts
+++ b/src/ai-review/openai.service.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 @Injectable()
 export class OpenAiService {
   private readonly apiKey = process.env.OPENAI_API_KEY;
-  private readonly model = process.env.OPENAI_MODEL || 'gpt-4';
+  private readonly model = process.env.OPENAI_MODEL || 'gpt-4'; // 모델을 지정
 
   async send(prompt: string): Promise<string> {
     const url = 'https://api.openai.com/v1/chat/completions';
@@ -17,7 +17,12 @@ export class OpenAiService {
     const data = {
       model: this.model,
       messages: [{ role: 'user', content: prompt }],
+      // 기본적으로 1개 메시지만 보내고 있음 (user → assistant)
+      // 원한다면 대화형 맥락도 줄 수 있음
       temperature: 0.7,
+      // 0 ~ 2 사이의 값
+      // 낮을수록 더 일관된 결과 (정확도 우선)
+      // 높을수록 더 창의적인 결과 (자유로운 응답)
     };
 
     const response = await axios.post(url, data, { headers });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,9 +8,10 @@ import { CodeModule } from './code/code.module';
 import { SessionModule } from './session/session.module';
 import { CollabEditorWebpublishGateway } from './collab-editor/collab-editor-webpublish.gateway';
 import { CollabEditorAlgorismGateway } from './collab-editor/collab-editor-algorism.gateway';
+import { AiReviewModule } from './ai-review/ai-review.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, UserModule, CodeModule, SessionModule],
+  imports: [PrismaModule, AuthModule, UserModule, CodeModule, SessionModule, AiReviewModule],
   controllers: [AppController],
   providers: [AppService, CollabEditorWebpublishGateway, CollabEditorAlgorismGateway],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ const config = new DocumentBuilder()
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors({
-    origin: 'http://localhost:5173',
+    origin: ['http://localhost:5173', 'https://codetogether-fulldevcourse.vercel.app'],
     credentials: true,
   });
   app.use(cookieParser());


### PR DESCRIPTION
## 작업 내용
- 세션 기반 AI 질문 기능 구현
  - `POST /sessions/:id/ai/review`: 세션의 codeLogs를 기반으로 AI에 코드 리뷰 질문 전송
  - `POST /sessions/:id/ai/question`: 코드 없이 일반 질문 전송
- 세션 정보는 Prisma의 `Session` 모델에서 조회
- 질문 + 코드 → OpenAI 프롬프트로 전달 후 응답 반환
- OpenAI API 연동 (`gpt-4-turbo` 기반)
  - 모델명, API 키는 `.env`에서 설정
  - 실패 시 에러 메시지 반환 및 예외 처리 추가
- 인증 필요 (`JwtAuthGuard` 적용)
- 코드가 없는 경우 `review` API는 예외 처리 (`codeLogs` 없을 시 404 반환)

## 엔드포인트

| 메서드 | 경로 | 설명 |
|--------|------|------|
| POST   | `/sessions/:id/ai/review`   | 세션 코드 기반 AI 코드 리뷰 질문 |
| POST   | `/sessions/:id/ai/question` | 일반 AI 질문 (코드 없음) |

## 참고 사항
- OpenAI 모델명 기본값: `gpt-4-turbo`
- `.env` 예시:
  - `OPENAI_API_KEY=sk-...`
  - `OPENAI_MODEL=gpt-4-turbo`
- OpenAiService 내부에서 프롬프트 전송 및 응답 추출 처리
- 추후 질문 로그 저장 기능 또는 질문 히스토리 조회 기능으로 확장 가능
